### PR TITLE
Add GNOME shell 40.5 to list of working shell-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Control all your Elgato Key Lights with one Control.
 
-This extension is only tested with gnome-shell 3.38 right now:
+This extension is only tested with gnome-shell **3.38** and **40.5** right now:
 
-    * master: 3.38
+    * master: 3.38, 40.5
 
 ![Screenshot](https://github.com/Cluster2a/gnome-shell-extension-elgato-light-control/raw/master/screenshot.png)
 

--- a/elgato-light-control@netadvising.de/metadata.json
+++ b/elgato-light-control@netadvising.de/metadata.json
@@ -6,7 +6,8 @@
   "settings-schema": "org.gnome.shell.extensions.elgato-light-control",
   "git-version": "v1",
   "shell-version": [
-    "3.38"
+    "3.38",
+    "40.5"
   ],
   "url": "https://git.netadvising.de/alex/gnome-shell-extension-elgato-key-light-control",
   "version": 1


### PR DESCRIPTION
This adds GNOME shell 40.5 to the list of supported extensions. It's the current shell version in Ubuntu 21.10.

I tested this locally with GNOME 40.5 and it works just as it did before with 3.38.